### PR TITLE
Fix typo in wordlist banner

### DIFF
--- a/Araclar/wordlist.py
+++ b/Araclar/wordlist.py
@@ -33,7 +33,7 @@ Wordlist Olusturma Aracina Hosgeldin R00T
         return
 
     os.system("clear")
-    os.system("figlet WORLDLIST R00T")
+    os.system("figlet WORDLIST R00T")
     print("""
 Wordlist Olusturma Aracina Hosgeldin R00T
     """)

--- a/tests/test_wordlist.py
+++ b/tests/test_wordlist.py
@@ -1,0 +1,9 @@
+import pathlib
+
+# Ensure that the modified line contains the correct spelling
+
+def test_wordlist_string_correct():
+    file_path = pathlib.Path('Araclar/wordlist.py')
+    content = file_path.read_text(encoding='utf-8')
+    assert "figlet WORDLIST R00T" in content
+    assert "WORLDLIST" not in content


### PR DESCRIPTION
## Summary
- fix the banner typo in `Araclar/wordlist.py`
- add regression test to ensure typo stays fixed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ff850c2e8833192f67137b480c778